### PR TITLE
Add signature secret on request header

### DIFF
--- a/app/workers/work_package_webhook_job.rb
+++ b/app/workers/work_package_webhook_job.rb
@@ -42,13 +42,14 @@ class WorkPackageWebhookJob < WebhookJob
 
   def perform
     body = request_body
+    headers = request_headers
     exception = nil
 
     if signature = request_signature(body)
-      request_headers['HTTP_X_OP_SIGNATURE'] = signature
+      headers['X-OP-Signature'] = signature
     end
 
-    response = RestClient.post webhook.url, request_body, request_headers
+    response = RestClient.post webhook.url, request_body, headers
   rescue RestClient::Exception => e
     response = e.response
 
@@ -62,7 +63,7 @@ class WorkPackageWebhookJob < WebhookJob
       webhook: webhook,
       event_name: event_name,
       url: webhook.url,
-      request_headers: request_headers,
+      request_headers: headers,
       request_body: body,
       response_code: response.try(:code).to_i,
       response_headers: response.try(:headers),


### PR DESCRIPTION
The fix updates the request header with the **signature secret**, once the original code try to change a immutable hash with the signature value.

And also, the signature header name is updated to follows the HTTP standard (ref: https://stackoverflow.com/a/3561399), and bring compatibility with other http servers (i.e. Python Django).